### PR TITLE
chore: Use higher memory requests and limits for build-container step

### DIFF
--- a/.tekton/caikit-nlp-pull-request.yaml
+++ b/.tekton/caikit-nlp-pull-request.yaml
@@ -30,6 +30,13 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      computeResources:
+        requests:
+          memory: 8Gi
+        limits:
+          memory: 10Gi
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/caikit-nlp-push.yaml
+++ b/.tekton/caikit-nlp-push.yaml
@@ -27,6 +27,13 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      computeResources:
+        requests:
+          memory: 8Gi
+        limits:
+          memory: 10Gi
   pipelineSpec:
     finally:
     - name: show-sbom


### PR DESCRIPTION
In `stone-prd-rh01` I see this:
```
max_over_time(
    container_memory_working_set_bytes{container=~".*step-build.*", pod=~".*-build-container-pod", namespace="rhoai-tenant", pod=~"caikit-nlp-.*"}
[1d])
```
![image](https://github.com/user-attachments/assets/bc35271f-4876-4ef3-8159-3a9a79656fb5)