### PR TITLE
Add konflux dockerfile

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -1,0 +1,56 @@
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as base
+
+RUN microdnf update -y && \
+    microdnf install -y \
+        git python-pip && \
+    pip install --upgrade --no-cache-dir pip wheel && \
+    microdnf clean all
+
+FROM base as builder
+WORKDIR /build
+
+RUN pip install --no-cache tox
+COPY README.md .
+COPY pyproject.toml .
+COPY tox.ini .
+COPY caikit_nlp caikit_nlp
+# .git is required for setuptools-scm get the version
+COPY .git .git
+RUN --mount=type=cache,target=/root/.cache/pip \
+     tox -e build && \
+     rm -rf .git
+
+
+FROM base as deploy
+
+RUN python -m venv --upgrade-deps /opt/caikit/
+
+ENV VIRTUAL_ENV=/opt/caikit
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+COPY --from=builder /build/dist/caikit_nlp*.whl /tmp/
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    microdnf install -y gcc python3-devel && \
+    pip install /tmp/caikit_nlp*.whl && \
+    rm /tmp/caikit_nlp*.whl && \
+    microdnf remove -y gcc python3-devel && \
+    microdnf clean all
+
+COPY LICENSE /opt/caikit/
+COPY README.md /opt/caikit/
+
+RUN groupadd --system caikit --gid 1001 && \
+    adduser --system --uid 1001 --gid 0 --groups caikit \
+    --home-dir /caikit --shell /sbin/nologin \
+    --comment "Caikit User" caikit
+
+USER caikit
+
+ENV RUNTIME_LIBRARY=caikit_nlp
+# Optional: use `CONFIG_FILES` and the /caikit/ volume to explicitly provide a configuration file and models
+# ENV CONFIG_FILES=/caikit/caikit.yml
+VOLUME ["/caikit/"]
+WORKDIR /caikit
+
+CMD ["python"]


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHOAIENG-32847 

We need to create Konflux versions of existing dockerfiles to enable product and Konflux-specific changes. For now, these will likely just be copies of the existing Dockerfile, but we’ll introduce changes in phase 2 when we start working on making the builds hermetic. 

This is standard across all RHOAI components, where each component maintains a dedicated Konflux Dockerfile for product builds.